### PR TITLE
FIX: filters not rendering on fresh category page load

### DIFF
--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -36,7 +36,8 @@ export default class TagGroupFilter extends Component {
     if (!Array.isArray(allowedTagGroups)) {
       try {
         const result = await Category.reloadById(categoryId);
-        const reloaded = result?.category?.allowed_tag_groups;
+        const category = this.site.updateCategory(result.category);
+        const reloaded = category?.allowed_tag_groups;
         allowedTagGroups = Array.isArray(reloaded) ? reloaded : [];
       } catch {
         allowedTagGroups = [];

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -33,12 +33,6 @@ export default class TagGroupFilter extends Component {
     const categoryId = this.category.id;
     let allowedTagGroups = this.category.allowed_tag_groups;
 
-    // Hosted Discourse omits `allowed_tag_groups` from the lightweight
-    // site-payload category (SiteCategorySerializer), even though it is present
-    // on the full category record. Fetch the full category when the field is
-    // missing so the filters still render on a fresh page load (otherwise
-    // `.length` below throws and nothing renders until a category edit hydrates
-    // the store record).
     if (!Array.isArray(allowedTagGroups)) {
       try {
         const result = await Category.reloadById(categoryId);

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -30,21 +30,31 @@ export default class TagGroupFilter extends Component {
       return;
     }
 
+    const categoryId = this.category.id;
     let allowedTagGroups = this.category.allowed_tag_groups;
 
-    // `allowed_tag_groups` is only serialized on the full category record, not
-    // on the categories preloaded in the site payload. On a fresh page load it
-    // is therefore undefined, so fetch the full category before reading it
-    // (otherwise `.length` below throws and no filters render until a category
-    // edit hydrates the store record).
-    if (!allowedTagGroups) {
-      const result = await Category.reloadById(this.category.id);
-
-      if (this.isDestroying || this.isDestroyed) {
-        return;
+    // Hosted Discourse omits `allowed_tag_groups` from the lightweight
+    // site-payload category (SiteCategorySerializer), even though it is present
+    // on the full category record. Fetch the full category when the field is
+    // missing so the filters still render on a fresh page load (otherwise
+    // `.length` below throws and nothing renders until a category edit hydrates
+    // the store record).
+    if (!Array.isArray(allowedTagGroups)) {
+      try {
+        const result = await Category.reloadById(categoryId);
+        const reloaded = result?.category?.allowed_tag_groups;
+        allowedTagGroups = Array.isArray(reloaded) ? reloaded : [];
+      } catch {
+        allowedTagGroups = [];
       }
+    }
 
-      allowedTagGroups = result?.category?.allowed_tag_groups || [];
+    if (
+      this.isDestroying ||
+      this.isDestroyed ||
+      this.category?.id !== categoryId
+    ) {
+      return;
     }
 
     if (allowedTagGroups.length) {
@@ -57,6 +67,14 @@ export default class TagGroupFilter extends Component {
       const { results } = await ajax(`/tag_groups/filter/search`, {
         data: { names: allowedTagGroups },
       });
+
+      if (
+        this.isDestroying ||
+        this.isDestroyed ||
+        this.category?.id !== categoryId
+      ) {
+        return;
+      }
 
       results.forEach((tagGroup) => {
         // Backward compatibility for https://github.com/discourse/discourse/pull/36678

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -44,7 +44,7 @@ export default class TagGroupFilter extends Component {
         return;
       }
 
-      allowedTagGroups = full?.category?.allowed_tag_groups || [];
+      allowedTagGroups = result?.category?.allowed_tag_groups || [];
     }
 
     if (allowedTagGroups.length) {

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -38,7 +38,7 @@ export default class TagGroupFilter extends Component {
     // (otherwise `.length` below throws and no filters render until a category
     // edit hydrates the store record).
     if (!allowedTagGroups) {
-      const full = await Category.reloadById(this.category.id);
+      const result = await Category.reloadById(this.category.id);
 
       if (this.isDestroying || this.isDestroyed) {
         return;

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -1,6 +1,7 @@
 /* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from "@ember/component";
 import { ajax } from "discourse/lib/ajax";
+import Category from "discourse/models/category";
 import { ALL_TAGS_ID } from "discourse/select-kit/components/tag-drop";
 import { i18n } from "discourse-i18n";
 import BoxTag from "./box-tag";
@@ -30,6 +31,21 @@ export default class TagGroupFilter extends Component {
     }
 
     let allowedTagGroups = this.category.allowed_tag_groups;
+
+    // `allowed_tag_groups` is only serialized on the full category record, not
+    // on the categories preloaded in the site payload. On a fresh page load it
+    // is therefore undefined, so fetch the full category before reading it
+    // (otherwise `.length` below throws and no filters render until a category
+    // edit hydrates the store record).
+    if (!allowedTagGroups) {
+      const full = await Category.reloadById(this.category.id);
+
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
+      allowedTagGroups = full?.category?.allowed_tag_groups || [];
+    }
 
     if (allowedTagGroups.length) {
       // get box style tag groups from setting

--- a/javascripts/discourse/components/tag-group-filter.gjs
+++ b/javascripts/discourse/components/tag-group-filter.gjs
@@ -1,5 +1,6 @@
 /* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from "@ember/component";
+import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import Category from "discourse/models/category";
 import { ALL_TAGS_ID } from "discourse/select-kit/components/tag-drop";
@@ -12,6 +13,8 @@ function parseSetting(setting) {
 }
 
 export default class TagGroupFilter extends Component {
+  @service site;
+
   dropdownGroups = [];
   boxGroups = [];
 

--- a/spec/system/page_objects/components/tag_group_filter.rb
+++ b/spec/system/page_objects/components/tag_group_filter.rb
@@ -13,6 +13,11 @@ module PageObjects
         has_css?("#{CATEGORY_OUTLET} .custom-box-group h4", text: name)
       end
 
+      def has_no_filter_groups?
+        has_no_css?("#{CATEGORY_OUTLET} .custom-dropdown-group") &&
+          has_no_css?("#{CATEGORY_OUTLET} .custom-box-group")
+      end
+
       def has_active_box_tag?(name)
         has_css?("#{CATEGORY_OUTLET} .custom-box-group li.active a", text: name)
       end

--- a/spec/system/tag_group_filters_spec.rb
+++ b/spec/system/tag_group_filters_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Tag group filters" do
   it "renders no filters and does not error for a category without tag groups" do
     category_without_tag_groups = Fabricate(:category)
 
-    visit("/c/#{category_without_tag_groups.slug}/#{category_without_tag_groups.id}")
+    visit(category_without_tag_groups.url)
 
     expect(page).to have_css(".category-navigation")
     expect(tag_group_filter).to have_no_filter_groups

--- a/spec/system/tag_group_filters_spec.rb
+++ b/spec/system/tag_group_filters_spec.rb
@@ -52,4 +52,13 @@ RSpec.describe "Tag group filters" do
     expect(page).to have_current_path("/c/#{category.slug}/#{category.id}")
     expect(tag_group_filter).to have_active_box_tag("All tags")
   end
+
+  it "renders no filters and does not error for a category without tag groups" do
+    category_without_tag_groups = Fabricate(:category)
+
+    visit("/c/#{category_without_tag_groups.slug}/#{category_without_tag_groups.id}")
+
+    expect(page).to have_css(".category-navigation")
+    expect(tag_group_filter).to have_no_filter_groups
+  end
 end

--- a/test/acceptance/tag-group-filter-test.gjs
+++ b/test/acceptance/tag-group-filter-test.gjs
@@ -1,0 +1,98 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import Category from "discourse/models/category";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import TagGroupFilter from "../../discourse/components/tag-group-filter";
+
+const CATEGORY = {
+  id: 5,
+  name: "General",
+  slug: "general",
+  path: "/c/general/5",
+};
+
+const TAG_GROUP_SEARCH = {
+  results: [
+    {
+      name: "Product",
+      tags: [{ id: 1, name: "widgets", slug: "widgets" }],
+    },
+  ],
+};
+
+module("Integration | Component | tag-group-filter", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    pretender.get("/tag_groups/filter/search", () =>
+      response(TAG_GROUP_SEARCH)
+    );
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  test("fetches the full category when allowed_tag_groups is missing", async function (assert) {
+    // A category from the site payload has no `allowed_tag_groups`, so the
+    // component must reload the full category before it can render filters.
+    pretender.get("/c/5/show.json", () =>
+      response({ category: { id: 5, allowed_tag_groups: ["Product"] } })
+    );
+
+    this.set("category", { ...CATEGORY });
+    this.set("tag", null);
+
+    await render(
+      <template>
+        <TagGroupFilter @category={{this.category}} @tag={{this.tag}} />
+      </template>
+    );
+
+    assert
+      .dom(".custom-dropdown-group h4")
+      .hasText(
+        "Product",
+        "renders the filter after reloading the full category"
+      );
+  });
+
+  test("does not error when the category reload fails", async function (assert) {
+    pretender.get("/c/5/show.json", () => response(404, {}));
+
+    this.set("category", { ...CATEGORY });
+    this.set("tag", null);
+
+    await render(
+      <template>
+        <TagGroupFilter @category={{this.category}} @tag={{this.tag}} />
+      </template>
+    );
+
+    assert
+      .dom(".custom-dropdown-group")
+      .doesNotExist(
+        "renders no filters when the full category cannot be loaded"
+      );
+  });
+
+  test("does not reload when allowed_tag_groups is already present", async function (assert) {
+    const reload = sinon.spy(Category, "reloadById");
+
+    this.set("category", { ...CATEGORY, allowed_tag_groups: ["Product"] });
+    this.set("tag", null);
+
+    await render(
+      <template>
+        <TagGroupFilter @category={{this.category}} @tag={{this.tag}} />
+      </template>
+    );
+
+    assert.true(reload.notCalled, "does not fetch the full category");
+    assert
+      .dom(".custom-dropdown-group h4")
+      .hasText("Product", "renders the filter from the preloaded category");
+  });
+});


### PR DESCRIPTION
The tag group filters don't show up on a category page when you load it directly (a fresh page load or a hard refresh). They only appear after you navigate away and back within the forum — for example by opening the category edit screen and returning.

The root cause is in `didInsertElement` in `tag-group-filter.gjs`:

```js
let allowedTagGroups = this.category.allowed_tag_groups;
if (allowedTagGroups.length) {
```

On a fresh load, `category` is present but `category.allowed_tag_groups` is **undefined**, so `allowedTagGroups.length` throws a `TypeError` and the component stops rendering before any filter is set. The reason is that `allowed_tag_groups` is only serialized on the full category record — it is not included on the categories preloaded in the site payload. Opening the category edit screen fetches the full category (`/c/{id}/show.json`), which hydrates the store record with `allowed_tag_groups`, and that is why it starts working after navigating back.

The fix fetches the full category when `allowed_tag_groups` is missing, before reading it:

```js
if (!allowedTagGroups) {
  const full = await Category.reloadById(this.category.id);
  if (this.isDestroying || this.isDestroyed) {
    return;
  }
  allowedTagGroups = full?.category?.allowed_tag_groups || [];
}
```

I verified this on a live site (a category with allowed tag groups configured): before the change the filters were missing on a fresh load and the console showed the `TypeError`; after the change all the dropdown and box filters render correctly on first load, without needing to navigate away and back.

I would say this affects any category with configured tag groups, since `allowed_tag_groups` is never in the preloaded site categories (so it isn't specific to one site).
